### PR TITLE
fix(alignment): social buttons vertical alignment

### DIFF
--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -56,6 +56,7 @@ footer {
 }
 
 .hero-footer {
+  align-items: center;
   display: flex;
   flex-direction: column;
   justify-content: space-between;


### PR DESCRIPTION
Fixing the vertical alignment and centering of social buttons w.r.t the '#BuildUpDevs' text.

![BuildUpDevs Alignment](https://user-images.githubusercontent.com/6317330/81083288-012b0000-8f12-11ea-97f3-e80a5ee6a67f.gif)
